### PR TITLE
Add dllexport to UValidationBPLibrary class

### DIFF
--- a/ValidationFramework/Source/ValidationFramework/Public/ValidationBPLibrary.h
+++ b/ValidationFramework/Source/ValidationFramework/Public/ValidationBPLibrary.h
@@ -28,7 +28,7 @@ limitations under the License.
 * 
 */
 UCLASS()
-class UValidationBPLibrary final : public UBlueprintFunctionLibrary
+class VALIDATIONFRAMEWORK_API UValidationBPLibrary final : public UBlueprintFunctionLibrary
 {
 	GENERATED_UCLASS_BODY()
 


### PR DESCRIPTION
Hi, I'm not sure if this is intentional or not, but can we add the VALIDATIONFRAMEWORK_API define to the UValidationBPLibrary class header? It's a very useful helper class which can now be used in other DLLs because of this change